### PR TITLE
feat: Support choosing the name of the socket used, and the directory it lives in.

### DIFF
--- a/src/SocketSmugglers.jl
+++ b/src/SocketSmugglers.jl
@@ -14,6 +14,9 @@ struct SocketSmuggler
     server::Base.IOServer
 end
 function SocketSmuggler(path)
+    if !Sys.iswindows()
+        mkpath(path)
+    end
     server = listen(path)
     @info "Ahoy, now smuggling from socket $path."
     SocketSmuggler(path, server)

--- a/src/SocketSmugglers.jl
+++ b/src/SocketSmugglers.jl
@@ -18,23 +18,6 @@ function SocketSmuggler(path)
     @info "Ahoy, now smuggling from socket $path."
     SocketSmuggler(path, server)
 end
-function SocketSmuggler()
-    path = ""
-    if Sys.isunix()
-        path = REPLSmuggler.yer_name()
-        while ispath(path)
-            path = REPLSmuggler.yer_name()
-        end
-        mkpath(dirname(path))
-        path
-    elseif Sys.iswindows()
-        path = REPLSmuggler.yer_name(joinpath=false)
-        path = replace("😭😭.😭pipe😭$path", "😭"=>"\\")
-    else
-        error("Can't create a UNIX Socket or equivalent on your platform.")
-    end
-    SocketSmuggler(path)
-end
 Base.isopen(s::SocketSmuggler) = isopen(s.server)
 Base.close(s::SocketSmuggler) = close(s.server)
 

--- a/src/SocketSmugglers.jl
+++ b/src/SocketSmugglers.jl
@@ -15,7 +15,7 @@ struct SocketSmuggler
 end
 function SocketSmuggler(path)
     if !Sys.iswindows()
-        mkpath(path)
+        mkpath(dirname(path))
     end
     server = listen(path)
     @info "Ahoy, now smuggling from socket $path."


### PR DESCRIPTION


BREAKING CHANGE: The signature of `smuggle` changed, see the documentation. It should not impact the default `smuggle()` usage.

Fixes partially #10.