### PR TITLE
feat(diagnostics): Use showerror to stringify error messages

### DIFF
--- a/src/Protocols.jl
+++ b/src/Protocols.jl
@@ -100,6 +100,8 @@ to sending an `exit` request.
 """
 module Protocols
 
+using ..REPLSmuggler: stringify_error
+
 "Name of the protocol implementation."
 const PROTOCOL_MAGIC = "REPLSmuggler"
 "Protocol version."
@@ -265,7 +267,7 @@ function Error(msgid, error::T, stackframe) where {T}
     ]
     ErrorResponse(
         msgid,
-        string(T), string(error), frames,
+        string(T), stringify_error(error), frames,
     )
 end
 function Error(exc::ProtocolException)

--- a/test/msgpackserializer.jl
+++ b/test/msgpackserializer.jl
@@ -30,7 +30,7 @@ using MsgPack
                 (file = "bar.jl", line = 2, func = "bar()"),
             ],
         )
-        expected_array = [Protocols.RESPONSE, 0x01, ["ErrorException", "ErrorException(\"Foo\")", [("foo.jl", 1, "foo()"), ("bar.jl", 2, "bar()")]], nothing]
+        expected_array = [Protocols.RESPONSE, 0x01, ["ErrorException", "ErrorException: Foo", [("foo.jl", 1, "foo()"), ("bar.jl", 2, "bar()")]], nothing]
         @testset "Error" test_msg(msg, expected_array)
 
         msg = Protocols.Result(1, "foo")

--- a/test/protocol.jl
+++ b/test/protocol.jl
@@ -55,7 +55,7 @@ using REPLSmuggler.Protocols
             Protocols.RESPONSE,
             1,
             (
-                "ErrorException", string(ErrorException("Foo")),
+                "ErrorException", "ErrorException: Foo",
                 [
                     ("foo.jl", 1, "foo()"),
                     ("bar.jl", 2, "bar()"),


### PR DESCRIPTION
This will, for example, give the following messages:
```
ErrorException
ErrorException: something is wrong
BoundsError: attempt to access 3-element Vector{Int64} at index [4]
```
instead of:
```
ErrorException("")
ErrorException("something is wrong")
BoundsError([1, 2, 3], (4,))
```
