### PR TITLE
feat: Smuggle exception stack

### DIFF
--- a/src/REPLSmuggler.jl
+++ b/src/REPLSmuggler.jl
@@ -150,4 +150,27 @@ function smuggle(exc::T, stackframes = stacktrace(Base.catch_backtrace())) where
     end
 end
 
+"""
+    smuggle(stacks::Base.ExceptionStack)
+
+Smuggle an exception stack. In the Julia REPL the `err` variable is implicitly defined and
+contains the stack from the last thrown error.
+
+# Examples
+```julia-repl
+julia> error("foo")
+ERROR: foo
+Stacktrace:
+[...]
+
+julia> smuggle(err)
+```
+"""
+function smuggle(stacks::Base.ExceptionStack)
+    # For nested exceptions there can be multiple stacks but for interactive use it should
+    # be good enough to just handle the first one.
+    stack = stacks[1]
+    return smuggle(stack.exception, stack.backtrace)
+end
+
 end


### PR DESCRIPTION
This patch adds a method to `smuggle` which handles `ExceptionStack`s. In the Julia REPL the `err` variable is implicitly defined and contains the stack from the last thrown exception. Thus, for code evaluated in the REPL directly (i.e. not through smuggling from neovim) this is very useful since `smuggle(err)` can be used instead of having to manually catch the error and backtrace.