### PR TITLE
added showsmuggler() , to show the current smuggler in the REPL

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,6 +26,8 @@ Task (runnable) @0x0000753a784c6bd0
 
 You are then able to send code and get notified when an error happens.
 
+At any point you can show the current smuggler by calling `showsmuggler()` in the REPL.
+
 `smuggle` can also be used the other way around, to directly send diagnostics
 to your editor. For example, if your editor has smuggled the following function:
 ```julia

--- a/src/REPLSmuggler.jl
+++ b/src/REPLSmuggler.jl
@@ -2,7 +2,7 @@ module REPLSmuggler
 
 using BaseDirs
 
-export smuggle
+export smuggle, showsmuggler
 
 const PROJECT = BaseDirs.Project("REPLSmuggler")
 
@@ -40,6 +40,17 @@ using .Server
 Store the current server.
 """
 CURRENT_SMUGGLER = nothing
+
+"""
+    Print the current smuggler path 
+"""
+function showsmuggler()
+    if CURRENT_SMUGGLER === nothing
+        println("No smuggler started, start one by running smuggle()")
+    else
+        println(CURRENT_SMUGGLER.vessel.path)
+    end
+end
 
 function smuggle(specific_smuggler, serializer)
     global CURRENT_SMUGGLER


### PR DESCRIPTION
i sometimes have two or three repls open and many vim instances open.

`SmuggleConfig` shows all the sockets , but one needs to know which repl is running which socket.

`showsmuggler` shows the current smuggler sockets path.