### PR TITLE
fix: fix bug, statementiterator for single char returns nothing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "REPLSmuggler"
 uuid = "ad7bff83-59f0-4382-9fe5-c2ac8aa77434"
 authors = ["Hugo Levy-Falk <hugo@klafyvel.me> and contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -10,7 +10,7 @@ Base.IteratorEltype(::Type{StatementsIterator}) = Base.HasEltype()
 Base.eltype(::Type{StatementsIterator}) = String
 
 function Base.iterate(s::StatementsIterator, current_index = 1)
-    if current_index ≥ lastindex(s.evalstring)
+    if current_index > lastindex(s.evalstring)
         return nothing
     end
     _, new_index = JuliaSyntax.parsestmt(


### PR DESCRIPTION
Regarding https://github.com/Klafyvel/nvim-smuggler/issues/35 , 
i've tracked it down to this line.

https://github.com/Klafyvel/REPLSmuggler.jl/blob/ab79c2ed160d84184916121a0168cebcf9214297/src/eval.jl#L12-L14

should be `if current_index > lastindex(s.evalstring)` , not `≥` ?

